### PR TITLE
added call to start-timer-manager to allow write-report to work

### DIFF
--- a/handin-server/grading-utils.rkt
+++ b/handin-server/grading-utils.rkt
@@ -97,7 +97,8 @@
                                 [else '()])))))  
            (define report-string (report->string users))
            (define report-delay (get-report-delay-in-minutes))
-           (start-timer (* 60 report-delay)
+           (start-timer (start-timer-manager)
+                        (* 60 report-delay)
                         (thunk
                          (with-output-to-file
                              (build-path dir 

--- a/handin-server/scribblings/grading-utils.scrbl
+++ b/handin-server/scribblings/grading-utils.scrbl
@@ -61,9 +61,9 @@ The following example illustrates a checker module using this infrastructure:
    
    (code:comment "Initialize max score")
    (set-test-max-score! 100)
-   
+
    (code:comment "Failure discounts 25 points")
-   (!test "Sample case 1"
+   (\@test "Sample case 1"
           "Error using even? predicate"
           (bar '(1 2 3 4) even?)
           '((2 4)(1 3))

--- a/handin-server/scribblings/grading-utils.scrbl
+++ b/handin-server/scribblings/grading-utils.scrbl
@@ -63,7 +63,7 @@ The following example illustrates a checker module using this infrastructure:
    (set-test-max-score! 100)
    
    (code:comment "Failure discounts 25 points")
-   (@test "Sample case 1"
+   (!test "Sample case 1"
           "Error using even? predicate"
           (bar '(1 2 3 4) even?)
           '((2 4)(1 3))

--- a/handin-server/scribblings/grading-utils.scrbl
+++ b/handin-server/scribblings/grading-utils.scrbl
@@ -206,7 +206,7 @@ way:
 (define-syntax (write-report stx)
    ...
    (define report-delay (get-report-delay-in-minutes))
-   (start-timer (* 60 report-delay) ...))
+   (start-timer (start-timer-manager) (* 60 report-delay) ...))
 ]
 
 The default behavior is obtained because @racket[get-report-delay-in-minutes]


### PR DESCRIPTION
It seems a bit silly to create a fresh timer manager for every call to start-timer, but 

* this call is inside a define-syntax, so it seems less fragile to just create it when needed, and
* this call is unlikely to happen more than once or twice per minute, if I understand correctly.